### PR TITLE
Small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *~
 src/cpulimit
+src/cpulimit.1
 busy
 process_iterator_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: c
 script:
   - make
-  - make test
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CC?=gcc
-CFLAGS?=-Wall -g -D_GNU_SOURCE
+CFLAGS?=-O2 -Wall -g -D_GNU_SOURCE
 TARGETS=cpulimit
 LIBS=list.o process_iterator.o process_group.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,20 +1,20 @@
-CC?=gcc
-CFLAGS?=-O2 -Wall -g -D_GNU_SOURCE
-BIN_TARGET=cpulimit
-MAN_TARGET=$(BIN_TARGET).$(MAN_SEC)
-TARGETS=$(BIN_TARGET) $(MAN_TARGET)
-LIBS=list.o process_iterator.o process_group.o
-UNAME := $(shell uname)
-PREFIX?=/usr/local
-BINDIR?=$(PREFIX)/bin
-HELP2MAN := $(shell which help2man)
-STRIP := $(shell which strip)
-MAN_NAME := "CPU Utilization Limiter"
-MAN_SEC := 1
-MAN_SRC := $(shell git remote get-url origin)
+BINDIR     ?= $(PREFIX)/bin
+BIN_TARGET  = cpulimit
+CC         ?=  gcc
+CFLAGS     ?= -O2 -Wall -g -D_GNU_SOURCE
+HELP2MAN   := $(shell which help2man)
+LIBS        = list.o process_iterator.o process_group.o
+MAN_NAME   := "CPU Utilization Limiter"
+MAN_SEC    := 1
+MAN_SRC    := $(shell git remote get-url origin)
+MAN_TARGET  = $(BIN_TARGET).$(MAN_SEC)
+PREFIX     ?= /usr/local
+STRIP      := $(shell which strip)
+TARGETS     = $(BIN_TARGET) $(MAN_TARGET)
+UNAME      := $(shell uname)
 
 ifeq ($(UNAME), FreeBSD)
-LIBS+=-lkvm
+LIBS       += -lkvm
 endif
 
 all::	$(TARGETS) $(LIBS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,7 @@ UNAME := $(shell uname)
 PREFIX?=/usr/local
 BINDIR?=$(PREFIX)/bin
 HELP2MAN := $(shell which help2man)
+STRIP := $(shell which strip)
 MAN_NAME := "CPU Utilization Limiter"
 MAN_SEC := 1
 MAN_SRC := $(shell git remote get-url origin)
@@ -21,13 +22,16 @@ all::	$(TARGETS) $(LIBS)
 static:
 	$(MAKE) all CFLAGS="$(CFLAGS) --static"
 
+strip: $(BIN_TARGET)
+	$(STRIP) $<
+
 install: $(TARGETS)
 	install $^ $(BINDIR)
 
-cpulimit:	cpulimit.c $(LIBS)
+$(BIN_TARGET):	cpulimit.c $(LIBS)
 	$(CC) -o cpulimit cpulimit.c $(LIBS) $(CFLAGS)
 
-$(MAN_TARGET): cpulimit $(HELP2MAN)
+$(MAN_TARGET): $(BIN_TARGET) $(HELP2MAN)
 	$(HELP2MAN) -n $(MAN_NAME) -s $(MAN_SEC) -s $(MAN_SRC) -N ./$< > $@
 
 process_iterator.o: process_iterator.c process_iterator.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,9 @@ CC?=gcc
 CFLAGS?=-O2 -Wall -g -D_GNU_SOURCE
 TARGETS=cpulimit
 LIBS=list.o process_iterator.o process_group.o
-
 UNAME := $(shell uname)
+PREFIX?=/usr/local
+BINDIR?=$(PREFIX)/bin
 
 ifeq ($(UNAME), FreeBSD)
 LIBS+=-lkvm
@@ -13,6 +14,9 @@ all::	$(TARGETS) $(LIBS)
 
 static:
 	$(MAKE) all CFLAGS="$(CFLAGS) --static"
+
+install: $(TARGETS)
+	install $^ $(BINDIR)
 
 cpulimit:	cpulimit.c $(LIBS)
 	$(CC) -o cpulimit cpulimit.c $(LIBS) $(CFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,9 @@ endif
 
 all::	$(TARGETS) $(LIBS)
 
+static:
+	$(MAKE) all CFLAGS="$(CFLAGS) --static"
+
 cpulimit:	cpulimit.c $(LIBS)
 	$(CC) -o cpulimit cpulimit.c $(LIBS) $(CFLAGS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,7 @@ MAN_SRC    := $(shell git remote get-url origin)
 MAN_TARGET  = $(BIN_TARGET).$(MAN_SEC)
 PREFIX     ?= /usr/local
 STRIP      := $(shell which strip)
+SUDO       := $(shell which sudo)
 TARGETS     = $(BIN_TARGET) $(MAN_TARGET)
 UNAME      := $(shell uname)
 
@@ -26,7 +27,7 @@ strip: $(BIN_TARGET)
 	$(STRIP) $<
 
 install: $(TARGETS)
-	install $^ $(BINDIR)
+	$(SUDO) install $^ $(BINDIR)
 
 $(BIN_TARGET):	cpulimit.c $(LIBS)
 	$(CC) -o cpulimit cpulimit.c $(LIBS) $(CFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,16 @@
 CC?=gcc
 CFLAGS?=-O2 -Wall -g -D_GNU_SOURCE
-TARGETS=cpulimit
+BIN_TARGET=cpulimit
+MAN_TARGET=$(BIN_TARGET).$(MAN_SEC)
+TARGETS=$(BIN_TARGET) $(MAN_TARGET)
 LIBS=list.o process_iterator.o process_group.o
 UNAME := $(shell uname)
 PREFIX?=/usr/local
 BINDIR?=$(PREFIX)/bin
+HELP2MAN := $(shell which help2man)
+MAN_NAME := "CPU Utilization Limiter"
+MAN_SEC := 1
+MAN_SRC := $(shell git remote get-url origin)
 
 ifeq ($(UNAME), FreeBSD)
 LIBS+=-lkvm
@@ -20,6 +26,9 @@ install: $(TARGETS)
 
 cpulimit:	cpulimit.c $(LIBS)
 	$(CC) -o cpulimit cpulimit.c $(LIBS) $(CFLAGS)
+
+$(MAN_TARGET): cpulimit $(HELP2MAN)
+	$(HELP2MAN) -n $(MAN_NAME) -s $(MAN_SEC) -s $(MAN_SRC) -N ./$< > $@
 
 process_iterator.o: process_iterator.c process_iterator.h
 	$(CC) -c process_iterator.c $(CFLAGS)

--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -130,7 +130,6 @@ static void print_usage(FILE *stream, int exit_code) {
     fprintf(stream, "      -p, --pid=N            pid of the process (implies -z)\n");
     fprintf(stream, "      -e, --exe=FILE         name of the executable program file or path name\n");
     fprintf(stream, "      COMMAND [ARGS]         run this command and limit it (implies -z)\n");
-    fprintf(stream, "\nReport bugs to <marlonx80@hotmail.com>.\n");
     exit(exit_code);
 }
 

--- a/src/cpulimit.c
+++ b/src/cpulimit.c
@@ -73,6 +73,8 @@
 
 #define MAX_PRIORITY -10
 
+#define VERSION "0.3"
+
 /* GLOBAL VARIABLES */
 
 //the "family"
@@ -119,6 +121,7 @@ static void print_usage(FILE *stream, int exit_code) {
     fprintf(stream, "   OPTIONS\n");
     fprintf(stream, "      -l, --limit=N                percentage of cpu allowed from 0 to %d (required)\n", 100*NCPU);
     fprintf(stream, "      -v, --verbose                show control statistics\n");
+    fprintf(stream, "      -V, --version                show program version number\n");
     fprintf(stream, "      -z, --lazy                   exit if there is no target process, or if it dies\n");
     fprintf(stream, "      -i, --include-children       limit also the children processes\n");
     fprintf(stream, "      -m, --minimum-limited-cpu=M  minimum percentage of cpu of target processes\n");
@@ -128,6 +131,11 @@ static void print_usage(FILE *stream, int exit_code) {
     fprintf(stream, "      -e, --exe=FILE         name of the executable program file or path name\n");
     fprintf(stream, "      COMMAND [ARGS]         run this command and limit it (implies -z)\n");
     fprintf(stream, "\nReport bugs to <marlonx80@hotmail.com>.\n");
+    exit(exit_code);
+}
+
+static void print_version(FILE *stream, int exit_code) {
+    fprintf(stream, "%s\n", VERSION);
     exit(exit_code);
 }
 
@@ -346,18 +354,19 @@ int main(int argc, char **argv) {
     int next_option;
     int option_index = 0;
     //A string listing valid short options letters
-    const char *short_options = "+p:e:l:vzim:h";
+    const char *short_options = "+p:e:l:vVzim:h";
     //An array describing valid long options
     const struct option long_options[] = {
-        { "pid",        required_argument, NULL, 'p' },
-        { "exe",        required_argument, NULL, 'e' },
-        { "limit",      required_argument, NULL, 'l' },
-        { "verbose",    no_argument,       NULL, 'v' },
-        { "lazy",       no_argument,       NULL, 'z' },
-        { "include-children", no_argument,  NULL, 'i' },
+        { "pid",        required_argument,     NULL, 'p' },
+        { "exe",        required_argument,     NULL, 'e' },
+        { "limit",      required_argument,     NULL, 'l' },
+        { "verbose",    no_argument,           NULL, 'v' },
+	{ "version",    no_argument,           NULL, 'V' },
+        { "lazy",       no_argument,           NULL, 'z' },
+        { "include-children", no_argument,     NULL, 'i' },
         { "minimum-limited-cpu", no_argument,  NULL, 'm' },
-        { "help",       no_argument,       NULL, 'h' },
-        { 0,            0,                 0,     0  }
+        { "help",       no_argument,           NULL, 'h' },
+        { 0,            0,                     0,     0  }
     };
 
     do {
@@ -378,6 +387,9 @@ int main(int argc, char **argv) {
         case 'v':
             verbose = 1;
             break;
+	case 'V':
+	    print_version(stdout, 0);
+	    break;
         case 'z':
             lazy = 1;
             break;

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,6 +15,8 @@ all::	$(TARGETS)
 static:
 	$(MAKE) all CFLAGS="$(CFLAGS) --static"
 
+install::
+
 busy:	busy.c
 	$(CC) -o busy busy.c $(SYSLIBS) $(CFLAGS)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,6 +12,9 @@ endif
 
 all::	$(TARGETS)
 
+static:
+	$(MAKE) all CFLAGS="$(CFLAGS) --static"
+
 busy:	busy.c
 	$(CC) -o busy busy.c $(SYSLIBS) $(CFLAGS)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,6 +2,7 @@ CC?=gcc
 CFLAGS?=-Wall -g
 TARGETS=busy process_iterator_test
 SRC=../src
+STRIP := $(shell which strip)
 SYSLIBS?=-lpthread
 LIBS=$(SRC)/list.o $(SRC)/process_iterator.o $(SRC)/process_group.o
 UNAME := $(shell uname)
@@ -14,6 +15,9 @@ all::	$(TARGETS)
 
 static:
 	$(MAKE) all CFLAGS="$(CFLAGS) --static"
+
+strip: $(TARGETS)
+	$(STRIP) $(TARGETS)
 
 install::
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,11 +1,11 @@
-CC?=gcc
-CFLAGS?=-Wall -g
-TARGETS=busy process_iterator_test
-SRC=../src
-STRIP := $(shell which strip)
-SYSLIBS?=-lpthread
-LIBS=$(SRC)/list.o $(SRC)/process_iterator.o $(SRC)/process_group.o
-UNAME := $(shell uname)
+CC      ?= gcc
+CFLAGS  ?= -Wall -g
+LIBS     = $(SRC)/list.o $(SRC)/process_iterator.o $(SRC)/process_group.o
+SRC      = ../src
+STRIP   := $(shell which strip)
+SYSLIBS ?= -lpthread
+TARGETS  = busy process_iterator_test
+UNAME   := $(shell uname)
 
 ifeq ($(UNAME), FreeBSD)
 LIBS+=-lkvm


### PR DESCRIPTION
* Add "--version" command-line option required by [help2man](https://www.gnu.org/software/help2man/).
* Add "static" target
* Add "-O2" optimization flag.
* Add "install" target.
* Remove outdated bug-reporting email address.
* Generate manpage via help2man.
* Remove redundant "make test" from .travis.yml
* Indent and sort Makefile rules.
* Add sudo to install command.